### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).