### PR TITLE
feat: add support for PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^7.0|^8.0",
-        "graham-campbell/guzzle-factory": "^3.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "graham-campbell/guzzle-factory": "^3.0|^4.0",
+        "guzzlehttp/guzzle": "^6.3|^7.2"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "guzzlehttp/guzzle": "^6.3|^7.2"
     },
     "require-dev": {
-        "graham-campbell/testbench-core": "^1.1",
+        "graham-campbell/testbench-core": "^3.2.2",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^6.5|^7.0|^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "graham-campbell/guzzle-factory": "^3.0",
         "guzzlehttp/guzzle": "^6.3"
     },


### PR DESCRIPTION
This adds PHP 8 support, and tests against PHP 8 in the CI. I don't think there are any code changes required as everything seemed to work correctly.